### PR TITLE
Remove redundant key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "minimal-react-parcel",
   "version": "1.0.0",
   "description": "A minimal React Parcel environment",
-  "main": "index.js",
   "scripts": {
     "start": "parcel ./src/index.html",
     "build": "parcel build ./src/index.html"


### PR DESCRIPTION
Hi Valentino,

I read your article on dev.to and made my way to this project.
It was inspiring and it got me started to create my own version [here](https://github.com/myTerminal/template-web-parcel) too :) .

I figured we could remove the 'main' key from package.json as it is not being used.
What do you think?

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valentinogagliardi/minimal-react-parcel/1)
<!-- Reviewable:end -->
